### PR TITLE
Feature/custom wp version

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -231,9 +231,9 @@ then
   $composer_exec install $composer_install_flags
 fi
 
-wp core download --version="${WP_VERSION}" --path="${PUBLIC_PATH}"  --force "${WP_DOWNLOAD_FLAGS}"
 chown -R "${APP_USER}:${APP_USER}" "$PUBLIC_PATH"
 
+wp core download --version="${WP_VERSION}" --force "${WP_DOWNLOAD_FLAGS}"
 
 $composer_exec copy:themes
 $composer_exec copy:assets

--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -232,6 +232,8 @@ then
 fi
 
 wp core download --version="${WP_VERSION}" --path="${PUBLIC_PATH}"  --force "${WP_DOWNLOAD_FLAGS}"
+chown -R "${APP_USER}:${APP_USER}" "$PUBLIC_PATH"
+
 
 $composer_exec copy:themes
 $composer_exec copy:assets

--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -231,10 +231,7 @@ then
   $composer_exec install $composer_install_flags
 fi
 
-$composer_exec download:wordpress
-
-$composer_exec reset:themes
-$composer_exec reset:plugins
+wp core download --version="${WP_VERSION}" --path="${PUBLIC_PATH}" "${WP_DOWNLOAD_FLAGS}"
 
 $composer_exec copy:themes
 $composer_exec copy:assets

--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -231,7 +231,7 @@ then
   $composer_exec install $composer_install_flags
 fi
 
-wp core download --version="${WP_VERSION}" --path="${PUBLIC_PATH}" "${WP_DOWNLOAD_FLAGS}"
+wp core download --version="${WP_VERSION}" --path="${PUBLIC_PATH}"  --force "${WP_DOWNLOAD_FLAGS}"
 
 $composer_exec copy:themes
 $composer_exec copy:assets

--- a/src/planet-4-151612/wordpress/templates/Dockerfile.in
+++ b/src/planet-4-151612/wordpress/templates/Dockerfile.in
@@ -80,4 +80,4 @@ ENV \
     WP_STATELESS_MEDIA_SERVICE_ACCOUNT="" \
     WP_THEME="planet4-master-theme" \
     WP_TITLE="Greenpeace" \
-    WP_VERSION="latest"
+    WP_VERSION="4.9.8"

--- a/src/planet-4-151612/wordpress/templates/Dockerfile.in
+++ b/src/planet-4-151612/wordpress/templates/Dockerfile.in
@@ -51,6 +51,7 @@ ENV \
     WP_DB_USER="" \
     WP_DEFAULT_CONTENT="true" \
     WP_DESCRIPTION="Greenpeace" \
+    WP_DOWNLOAD_FLAGS="--skip-content" \
     WP_EXTRA_CONFIG="" \
     WP_FORCE_SSL_ADMIN="true" \
     WP_HOSTNAME="" \

--- a/tests/src/planet-4-151612/wordpress/docker-compose.yml
+++ b/tests/src/planet-4-151612/wordpress/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - GIT_REF=${GIT_BRANCH}
       - MERGE_SOURCE=
       - WP_TITLE=${WP_TITLE}
+      - WP_VERSION=${WP_VERSION:-latest}
     env_file:
       - db.env
     volumes:

--- a/tests/src/planet-4-151612/wordpress/tests/30_test_wp-cli.bats
+++ b/tests/src/planet-4-151612/wordpress/tests/30_test_wp-cli.bats
@@ -18,6 +18,13 @@ function teardown {
   [[ $status -eq 0 ]]
 }
 
+@test "wp-cli gets wordpress version" {
+  run docker-compose -f "${BATS_TEST_DIRNAME}/../docker-compose.yml" exec php-fpm wp core version
+  [ $status -eq 0 ]
+  version_detect="[[:digit:]]+\\.[[:digit:]]+"
+  printf '%s' "$output" | grep -Eq "$version_detect"
+}
+
 @test "wp-cli get blogname == ${WP_TITLE}" {
   run docker-compose -f "${BATS_TEST_DIRNAME}/../docker-compose.yml" exec php-fpm wp option get blogname
   [[ $status -eq 0 ]]

--- a/tests/src/planet-4-151612/wordpress/tests/40_cleanup.bats
+++ b/tests/src/planet-4-151612/wordpress/tests/40_cleanup.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+set -e
+
+load env
+
+function setup {
+  begin_output
+}
+
+function teardown {
+  store_output
+}
+
+@test "container cleans up" {
+  run clean_docker_compose "${compose_file}"
+  [[ "$status" -eq 0 ]]
+}

--- a/tests/src/planet-4-151612/wordpress/tests/50_wp_fixed_version.bats
+++ b/tests/src/planet-4-151612/wordpress/tests/50_wp_fixed_version.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+set -e
+
+load env
+
+export WP_VERSION=4.9.7
+
+function setup {
+  begin_output
+}
+
+function teardown {
+  store_output
+}
+
+@test "shutdown existing containers" {
+  docker-compose -f "${compose_file}" down -v
+}
+
+@test "docker compose start $IMAGE_TAG" {
+  # Wait up to 10 minutes for the build to complete!
+  run start_docker_compose "${BATS_TEST_DIRNAME}/../docker-compose.yml" http://localhost:80 proxy 20
+  [ $status -eq 0 ]
+}
+
+@test "wordpress version $WP_VERSION" {
+  run docker-compose -f "${BATS_TEST_DIRNAME}/../docker-compose.yml" exec php-fpm wp core version
+  [ $status -eq 0 ]
+  printf '%s' "$output" | grep -Eq "$WP_VERSION"
+}
+
+@test "responds on port 80 with status 200" {
+  run curl_check_status_code 200 http://localhost:80 proxy 10
+  [ $status -eq 0 ]
+  [ $output -eq 200 ]
+}
+
+@test "response contains string greenpeace" {
+  run curl_check_response_regex "greenpeace" http://localhost:80 proxy 5
+  [ $status -eq 0 ]
+}
+
+@test "response does not contain string FNORDPTANGWIBBLE" {
+  run curl_check_response_regex "FNORDPTANGWIBBLE" http://localhost:80 proxy 1
+  [ $status -ne 0 ]
+}

--- a/tests/src/planet-4-151612/wordpress/tests/env.bash
+++ b/tests/src/planet-4-151612/wordpress/tests/env.bash
@@ -21,9 +21,15 @@ GIT_SOURCE="https://github.com/greenpeace/planet4-base-fork"
 GIT_BRANCH="develop"
 RANDOM_TITLE="Test-mcBkUCqAO3yCvAjy"
 WP_TITLE="Greenpeace - Testing"
+
+OPENRESTY_BUILD_TAG=${OPENRESTY_IMAGE_TAG:-$IMAGE_TAG}
+WORDPRESS_BUILD_TAG=${WORDPRESS_BUILD_TAG:-$IMAGE_TAG}
+
 export APP_HOSTNAME
 export DB_IMAGE
-export GIT_SOURCE
 export GIT_BRANCH
+export GIT_SOURCE
+export OPENRESTY_BUILD_TAG
 export RANDOM_TITLE
+export WORDPRESS_BUILD_TAG
 export WP_TITLE


### PR DESCRIPTION
Installs Wordpress via wp-cli instead of composer

Version currently pinned at 4.9.8, but will be overridden in planet4-builder via CircleCI environment variable in a subsequent PR, and the line in `templates/Dockerfile.in` set to 'latest' once that is in effect.

Tests successful at: https://circleci.com/gh/greenpeace/planet4-docker/3164

Including: builds and content checks in 'latest' as well as version pinned at 4.9.7

