### PR TITLE
PLANET-5158: Give composer files to user app

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -113,9 +113,9 @@ then
     _good "Test data detected, deleting source directories..."
     delete_source_directories
   else
-    _warn "Unknown file detected"
-    cat "${PUBLIC_PATH}/index.php"
-    _warn "Attempting to continue ..."
+    _warning "Unknown file detected"
+    cat "${PUBLIC_PATH}/index.php" || true
+    _warning "Attempting to continue ..."
   fi
 elif [[ "${num_files}" -gt 0 ]]
 then
@@ -144,7 +144,7 @@ fi
 create_source_directories
 
 _good "Setting permissions of /app to ${APP_USER}..."
-chown -R "${APP_USER}" /app || true
+find /app ! -user "${APP_USER}" -exec chown -f "${APP_USER}" {} \;
 
 # ==============================================================================
 # ENVIRONMENT VARIABLE CHECKS
@@ -215,7 +215,7 @@ then
   rsync -a --exclude=.* . "${SOURCE_PATH}"
 fi
 
-composer_exec="time composer -vv --no-ansi"
+composer_exec="time setuser ${APP_USER} composer -vv --no-ansi"
 
 # if [[ ! -d "${SOURCE_PATH}/composer.lock" ]]
 # then
@@ -229,6 +229,12 @@ then
 else
   composer_install_flags=" --prefer-dist --no-dev"
 fi
+
+_good "Setting permissions of composer to ${APP_USER}..."
+chown -f "${APP_USER}" /app/bin/composer
+
+_good "Setting permissions of /app to ${APP_USER}..."
+find /app ! -user "${APP_USER}" -exec chown -f "${APP_USER}" {} \;
 
 cd "${SOURCE_PATH}"
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5158
Follows: #47 

A command `make nro-enable` would return an error because `/app/.composer` is owned by `root`.  
This was caused by #47, composer now doesn't execute a full chown before running, which keeps original rights on files.

## Fix

- Run `composer` with user `app` when possible
- Give ownership of composer related files to `app`

### Other changes

- Fixed `_warn` function to `_warning`  
  `_warn` does not exist
- Made the `cat "${PUBLIC_PATH}/index.php"` ok with `index.php` not existing  
  stumbled on the error while doing some test, doesn't look like it should fail

## Test

A `make dev` followed by `make nro-enable` shouldn't raise any access rights error.