### PR TITLE
Add rsync for assets built for branches of composer deps

### DIFF
--- a/src/planet-4-151612/openresty/templates/Dockerfile.in
+++ b/src/planet-4-151612/openresty/templates/Dockerfile.in
@@ -53,3 +53,8 @@ RUN groupadd -g "${APP_GID}" "${APP_GROUP}" && \
     echo "Country: __P4_GEOIP_COUNTRY_CODE__" >> "${PUBLIC_PATH}/index.html"
 
 COPY . /app/
+
+RUN \
+    if [ -d ${SOURCE_PATH}/built-dev-assets/ ]; then \
+        rsync -av ${SOURCE_PATH}/built-dev-assets/ ${SOURCE_PATH}/ && rm -rf ${SOURCE_PATH}/built-dev-assets; \
+    fi


### PR DESCRIPTION
A quick fix to do the same rsync of the built dev assets into the right place as happens in https://github.com/greenpeace/planet4-builder/blob/bd85d7192fa61db1bb25a9a2a98464abed9ae571/src/build/Dockerfile.in#L35-L35

Without the rsync the files are missing.