### PR TITLE
Add hostname as string literal

### DIFF
--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -9,25 +9,13 @@ define('DB_HOST',     '{{ .Env.WP_DB_HOST}}:{{ .Env.WP_DB_PORT }}');
 define('DB_CHARSET',  '{{ .Env.WP_DB_CHARSET }}');
 define('DB_COLLATE',  '{{ .Env.WP_DB_COLLATION }}');
 
-/* Respect upstream SSL termination headers */
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
-    $_SERVER['HTTPS']='on';
-    $protocol='https';
-} else {
-    $protocol='http';
-}
-
-if (isset($_SERVER['HTTP_VIA']) && strpos($_SERVER['HTTP_VIA'], 'akamai') !== false) {
-  $_SERVER['HTTP_HOST']='www.greenpeace.org';
-}
-
 if (!isset($_SERVER['HTTP_HOST'])) {
   # Circumvent HTTP_HOST array key not set messages when using wp-cli
   $_SERVER['HTTP_HOST']='{{ .Env.APP_HOSTNAME }}';
 }
 
-define('WP_SITEURL',  $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
-define('WP_HOME',     $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
+define('WP_SITEURL',  'https://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
+define('WP_HOME',     'https://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
 
 define('WP_AUTO_UPDATE_CORE', '{{ .Env.WP_AUTO_UPDATE_CORE }}' );
 

--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -23,7 +23,7 @@ if (isset($_SERVER['HTTP_VIA']) && strpos($_SERVER['HTTP_VIA'], 'akamai') !== fa
 
 if (!isset($_SERVER['HTTP_HOST'])) {
   # Circumvent HTTP_HOST array key not set messages when using wp-cli
-  $_SERVER['HTTP_HOST']='';
+  $_SERVER['HTTP_HOST']='{{ .Env.APP_HOSTNAME }}';
 }
 
 define('WP_SITEURL',  $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');

--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -26,8 +26,8 @@ if (!isset($_SERVER['HTTP_HOST'])) {
   $_SERVER['HTTP_HOST']='';
 }
 
-define('WP_SITEURL',  $protocol . '://' . $_SERVER['HTTP_HOST'] . '{{ .Env.APP_HOSTPATH }}');
-define('WP_HOME',     $protocol . '://' . $_SERVER['HTTP_HOST'] . '{{ .Env.APP_HOSTPATH }}');
+define('WP_SITEURL',  $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
+define('WP_HOME',     $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
 
 define('WP_AUTO_UPDATE_CORE', '{{ .Env.WP_AUTO_UPDATE_CORE }}' );
 


### PR DESCRIPTION
This would solve the issue of CLI not using the correct site url, and I don't think we need the image to be able to work with a different hostname on the fly, but maybe I'm missing something :thinking: 

`APP_HOSTPATH` already has the "/" prepended, it is added somewhere before.

I also modified the fallback when `HTTP_HOST` is not set to use the same value, instead of an empty string. Note that it had always had an empty string there, so some things that never worked might start working, which could cause issues.