### PR TITLE
Re-add protocol config

### DIFF
--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -9,13 +9,21 @@ define('DB_HOST',     '{{ .Env.WP_DB_HOST}}:{{ .Env.WP_DB_PORT }}');
 define('DB_CHARSET',  '{{ .Env.WP_DB_CHARSET }}');
 define('DB_COLLATE',  '{{ .Env.WP_DB_COLLATION }}');
 
+/* Respect upstream SSL termination headers */
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
+    $_SERVER['HTTPS']='on';
+    $protocol='https';
+} else {
+    $protocol='http';
+}
+
 if (!isset($_SERVER['HTTP_HOST'])) {
   # Circumvent HTTP_HOST array key not set messages when using wp-cli
   $_SERVER['HTTP_HOST']='{{ .Env.APP_HOSTNAME }}';
 }
 
-define('WP_SITEURL',  'https://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
-define('WP_HOME',     'https://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
+define('WP_SITEURL',  $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
+define('WP_HOME',     $protocol . '://{{ .Env.APP_HOSTNAME }}{{ .Env.APP_HOSTPATH }}');
 
 define('WP_AUTO_UPDATE_CORE', '{{ .Env.WP_AUTO_UPDATE_CORE }}' );
 


### PR DESCRIPTION
It looks like the protocol variable is needed when docker-compose is ran in CI, so I added this part again that was removed in https://github.com/greenpeace/planet4-docker/pull/56

Tested on master-theme: https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/2518/workflows/d5b45307-df4f-4161-8721-800e7ac515c7/jobs/12743 The workflow still fails there, but after the point where it got stuck before, and due to changes in the repo itself.