### PR TITLE
Specify WP_VERSION in code

### DIFF
--- a/src/planet-4-151612/wordpress/templates/Dockerfile.in
+++ b/src/planet-4-151612/wordpress/templates/Dockerfile.in
@@ -85,4 +85,4 @@ ENV \
     WP_STATELESS_MEDIA_SERVICE_ACCOUNT="" \
     WP_THEME="planet4-master-theme" \
     WP_TITLE="Greenpeace" \
-    WP_VERSION="latest"
+    WP_VERSION="5.4.2"


### PR DESCRIPTION
So that we can remove the environment variable in CircleCI, where it is
treated as a secret and so masked in all job output. I guess we can
manage it here instead in the default of the env var, then remove it
from org-global