### PR TITLE
Clean up install lock on shutdown

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.post_shutdown.d/20_cleanup.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.post_shutdown.d/20_cleanup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+install_lock="${SOURCE_PATH}/.install"
+
+echo "Cleaning up..."
+
+# Remove install lock  to avoid neverending install after crash
+if [ -f "${install_lock}" ]
+then
+    echo "Removing install lock"
+    rm -f "${install_lock}"
+fi
+
+echo "Clean up done."


### PR DESCRIPTION
When the wordpress container crashes during wordpress install, the install lock file can stay there and block any subsequent install attempt, until container is destroyed.
This lock is mentioned in logs but not visible to the user waiting for its install to finish, which leads to neverending waiting times and a puzzled end-user.

## Fix

Make sure the install lock file is removed by adding a cleanup script to the shutdown process, so that when the install fails it doesn't keep the lock in place.  
Shutdown process is based on [the phusion image we use](https://github.com/phusion/baseimage-docker/blob/4646d893db9778ff2fd386b387eb5f46b88b92d0/image/bin/my_init#L283) as a base.

## Test

Reading the logs during a `make stop`, you can see the shutdown process, including the cleanup part.
```sh
php-fpm_1        | 2021-01-27T10:40:15.952352508Z 2021/01/27 10:40:15 Received signal: terminated
php-fpm_1        | 2021-01-27T10:40:15.965321358Z 2021/01/27 10:40:15 Command finished successfully.
php-fpm_1        | 2021-01-27T10:40:16.372249832Z *** Shutting down runit daemon (PID 140)...
php-fpm_1        | 2021-01-27T10:40:16.414857896Z *** Running /etc/my_init.post_shutdown.d/10_syslog-ng.shutdown...
php-fpm_1        | 2021-01-27T10:40:16.421713529Z Jan 27 10:40:16 e1d3bdbfd45f syslog-ng[46]: syslog-ng shutting down; version='3.13.2'
php-fpm_1        | 2021-01-27T10:40:17.434270538Z *** Running /etc/my_init.post_shutdown.d/20_cleanup.sh...
php-fpm_1        | 2021-01-27T10:40:17.440408521Z Cleaning up...
php-fpm_1        | 2021-01-27T10:40:17.440491383Z Clean up done.
php-fpm_1        | 2021-01-27T10:40:17.441103182Z *** Init system aborted.
php-fpm_1        | 2021-01-27T10:40:17.441171285Z *** Killing all processes...

```