### PR TITLE
Allow turning on theme editor on dev envs

### DIFF
--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -61,6 +61,7 @@ define('NONCE_SALT',       '{{ .Env.WP_NONCE_SALT }}');
 define( 'WP_DEBUG', true );
 define( 'WP_DEBUG_LOG', true );
 define( 'SCRIPT_DEBUG', true );
+define( 'ALLOW_EXPERIMENTAL_FEATURES', true );
 {{ end }}
 
 {{ if eq .Env.WP_STATELESS_MEDIA_ENABLED "true" }}


### PR DESCRIPTION
This will prevent the checkbox to allow theme editor for non-logged in from being shown in production environments. It's also checked even if the feature would somehow be turned on on production. See https://github.com/greenpeace/planet4-master-theme/pull/1173/commits/b831e4ff4a289a7a3ed6e95b51bb5a6bc34c8d5e