### PR TITLE
PLANET-6017: Give composer script permissions before wp check

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -5,6 +5,10 @@ set -e
 
 install_lock="${SOURCE_PATH}/.install"
 
+_good "Setting permissions of composer to ${APP_USER}..."
+chown -f "${APP_USER}" /app/bin/composer
+chown -fR "${APP_USER}" /app/.composer
+
 # ==============================================================================
 # UTILITY FUNCTIONS
 # ==============================================================================
@@ -211,9 +215,6 @@ if [[ $APP_ENV =~ develop ]]; then
 else
   composer_install_flags=" --prefer-dist --no-dev"
 fi
-
-_good "Setting permissions of composer to ${APP_USER}..."
-chown -f "${APP_USER}" /app/bin/composer
 
 _good "Setting permissions of /app to ${APP_USER}..."
 find /app ! -user "${APP_USER}" -exec chown -f "${APP_USER}" {} \;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6017

> Composer permission to 'app' user are lost when containers are removed and re-created. This happens at any time docker uses docker-compose down && docker-compose up commands.

## Issue

Running `make down` or `docker-compose down` removes containers; on the next run they are rebuilt. Each time, script `20_install_wordpress.sh` runs; if it does an installation it also fixes permissions issues, but if it finds a wordpress installation it skips all operations in the script.

```console
> make dev
> docker-compose exec -u app php-fpm composer licenses
// display packages licenses
> make down && make up
> docker-compose exec -u app php-fpm composer licenses
// fails
bash: /app/bin/composer: Permission denied
```
Composer is not owned by `app` because it is installed by root, and before user `app` is created.

## Fix

The easiest/smallest fix is to fix composer permissions issues every time, before wordpress install is detected.  
A ideal long term fix would be to run the container with its user `app`, but due to issues in the image used itself and dependencies to its execution it does not seem possible, and it would take a lot more work to make it happen.

## Test

Stop your local installation. In a different folder, clone planet4-docker-compose and run local dev with an image built on this branch: 

```console
> git clone https://github.com/greenpeace/planet4-docker-compose.git p4test && cd p4test
> APP_IMAGE=gcr.io/planet-4-151612/wordpress:fix-composer-permissions make dev
> docker-compose exec -u app php-fpm composer licenses
// display packages licenses
> make down && APP_IMAGE=gcr.io/planet-4-151612/wordpress:fix-composer-permissions make up
> docker-compose exec -u app php-fpm composer licenses
// should still display packages licenses

```