### PR TITLE
PLANET-6051 Replace Microscanner with Trivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,15 +204,14 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Microscanner
+          name: Trivy
           command: |
-            if docker run --rm -ti "gcr.io/${GOOGLE_PROJECT_ID}/openresty:build-$(cat /tmp/workspace/var/circle-build-num)" /microscanner ${MICROSCANNER_TOKEN}
-            then
-              echo "@todo: list vulnerabilities"
-            else
-              TYPE="Vulnerability Scan" notify-job-failure.sh
-              exit 1
-            fi
+            mkdir -p /tmp/trivy-results
+            trivy --exit-code 0 image \
+              "gcr.io/${GOOGLE_PROJECT_ID}/openresty:build-$(cat /tmp/workspace/var/circle-build-num)" \
+              > /tmp/trivy-results/report.txt
+      - store_artifacts:
+          path: /tmp/trivy-results
 
   scan-php-fpm:
     <<: *defaults
@@ -222,15 +221,14 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Microscanner
+          name: Trivy
           command: |
-            if docker run --rm -ti "gcr.io/${GOOGLE_PROJECT_ID}/php-fpm:build-$(cat /tmp/workspace/var/circle-build-num)" /microscanner ${MICROSCANNER_TOKEN}
-            then
-              echo "@todo: list vulnerabilities"
-            else
-              TYPE="Vulnerability Scan" notify-job-failure.sh
-              exit 1
-            fi
+            mkdir -p /tmp/trivy-results
+            trivy --exit-code 0 image \
+              "gcr.io/${GOOGLE_PROJECT_ID}/php-fpm:build-$(cat /tmp/workspace/var/circle-build-num)" \
+              > /tmp/trivy-results/report.txt
+      - store_artifacts:
+          path: /tmp/trivy-results
 
   scan-wordpress:
     <<: *defaults
@@ -240,15 +238,14 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Microscanner
+          name: Trivy
           command: |
-            if docker run --rm -ti "gcr.io/${GOOGLE_PROJECT_ID}/wordpress:build-$(cat /tmp/workspace/var/circle-build-num)" /microscanner ${MICROSCANNER_TOKEN}
-            then
-              echo "@todo: list vulnerabilities"
-            else
-              TYPE="Vulnerability Scan" notify-job-failure.sh
-              exit 1
-            fi
+            mkdir -p /tmp/trivy-results
+            trivy --exit-code 0 image \
+              "gcr.io/${GOOGLE_PROJECT_ID}/wordpress:build-$(cat /tmp/workspace/var/circle-build-num)" \
+              > /tmp/trivy-results/report.txt
+      - store_artifacts:
+          path: /tmp/trivy-results
 
   scan-handbook:
     <<: *defaults
@@ -258,15 +255,14 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Microscanner
+          name: Trivy
           command: |
-            if docker run --rm -ti "gcr.io/${GOOGLE_PROJECT_ID}/handbook:build-$(cat /tmp/workspace/var/circle-build-num)" /microscanner ${MICROSCANNER_TOKEN}
-            then
-              echo "@todo: list vulnerabilities"
-            else
-              TYPE="Vulnerability Scan" notify-job-failure.sh
-              exit 1
-            fi
+            mkdir -p /tmp/trivy-results
+            trivy --exit-code 0 image \
+              "gcr.io/${GOOGLE_PROJECT_ID}/handbook:build-$(cat /tmp/workspace/var/circle-build-num)" \
+              > /tmp/trivy-results/report.txt
+      - store_artifacts:
+          path: /tmp/trivy-results
 
   scan-exim:
     <<: *defaults
@@ -276,15 +272,14 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Microscanner
+          name: Trivy
           command: |
-            if docker run --rm -ti "gcr.io/${GOOGLE_PROJECT_ID}/exim:build-$(cat /tmp/workspace/var/circle-build-num)" /microscanner ${MICROSCANNER_TOKEN}
-            then
-              echo "@todo: list vulnerabilities"
-            else
-              TYPE="Vulnerability Scan" notify-job-failure.sh
-              exit 1
-            fi
+            mkdir -p /tmp/trivy-results
+            trivy --exit-code 0 image \
+              "gcr.io/${GOOGLE_PROJECT_ID}/exim:build-$(cat /tmp/workspace/var/circle-build-num)" \
+              > /tmp/trivy-results/report.txt
+      - store_artifacts:
+          path: /tmp/trivy-results
 
   deploy:
     <<: *defaults

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 Dockerfile
-MICROSCANNER_TOKEN

--- a/.yamllint
+++ b/.yamllint
@@ -2,4 +2,5 @@
 extends: default
 
 rules:
-  line-length: disable
+  line-length:
+    max: 120

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ include $(CONFIG)
 export $(shell sed 's/=.*//' config.custom)
 endif
 
-MICROSCANNER_TOKEN ?= $(shell cat MICROSCANNER_TOKEN)
-export MICROSCANNER_TOKEN
-
 # Pass TEST_FOLDERS env variable to limit which tests to run
 TEST_FOLDERS ?=
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -36,23 +36,9 @@ sendBuildRequest() {
     "_BUILD_NUM=${BUILD_NUM}"
     "_BUILD_NAMESPACE=${BUILD_NAMESPACE}"
     "_BUILD_TAG=${BUILD_TAG}"
-    "_MICROSCANNER_TOKEN=${MICROSCANNER_TOKEN}"
     "_GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}"
     "_REVISION_TAG=${REVISION_TAG}"
   )
-
-  for i in "${!sub_array[@]}"; do
-    # _MICROSCANNER_TOKEN is not present in all builds as an ARG
-    # Remove the token from substitution data to prevent missing var error
-    if ! grep -q "$(echo "${sub_array[$i]}" | cut -d'=' -f1)" "$dir/cloudbuild.yaml"; then
-      _notice "Removing _MICROSCANNER_TOKEN from substring replacement array"
-      for j in "${!sub_array[@]}"; do
-        if [[ "${sub_array[$j]}" = "_MICROSCANNER_TOKEN=${MICROSCANNER_TOKEN}" ]]; then
-          unset "sub_array[$j]"
-        fi
-      done
-    fi
-  done
 
   sub="$(printf "%s," "${sub_array[@]}")"
   sub="${sub%,}"
@@ -209,19 +195,10 @@ if [[ "${BUILD_LOCALLY}" = "true" ]]; then
     fi
     _build "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${BUILD_TAG} ..."
 
-    if grep -q '^ARG MICROSCANNER_TOKEN' "$build_dir/Dockerfile"; then
-      _notice "Microscanner detected"
-      time docker build \
-        --build-arg "MICROSCANNER_TOKEN=$MICROSCANNER_TOKEN" \
-        -t "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${BUILD_TAG}" \
-        -t "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${REVISION_TAG}" \
-        "${build_dir}"
-    else
-      time docker build \
-        -t "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${BUILD_TAG}" \
-        -t "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${REVISION_TAG}" \
-        "${build_dir}"
-    fi
+    time docker build \
+      -t "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${BUILD_TAG}" \
+      -t "${BUILD_NAMESPACE}/${GOOGLE_PROJECT_ID}/${image}:${REVISION_TAG}" \
+      "${build_dir}"
     echo
   done
 fi

--- a/bin/inc/main
+++ b/bin/inc/main
@@ -196,15 +196,6 @@ if [[ "${CIRCLECI:-}" ]]; then
 
 fi
 
-if [[ -z "${MICROSCANNER_TOKEN:-}" ]]; then
-  if [[ "${BUILD_LOCALLY}" = "true" ]] || [[ "${BUILD_REMOTELY}" = "true" ]]; then
-    echo >&2 "ERROR: Environment variable MICROSCANNER_TOKEN not set."
-    echo >&2 "See: https://github.com/aquasecurity/microscanner#registering-for-a-token"
-    echo >&2 ""
-    exit 1
-  fi
-fi
-
 BRANCH_NAME_RAW=${CIRCLE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 BRANCH_NAME=${BRANCH_NAME_RAW//[^a-zA-Z0-9\._-]/-}
 

--- a/src/greenpeace-testing/cloudbuild.yaml
+++ b/src/greenpeace-testing/cloudbuild.yaml
@@ -15,8 +15,6 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
-      - '--build-arg'
-      - 'MICROSCANNER_TOKEN=${_MICROSCANNER_TOKEN}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_TAG}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_NUM}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_REVISION_TAG}'

--- a/src/greenpeace-testing/hello-world/cloudbuild.yaml
+++ b/src/greenpeace-testing/hello-world/cloudbuild.yaml
@@ -4,8 +4,6 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
-      - '--build-arg'
-      - 'MICROSCANNER_TOKEN=${_MICROSCANNER_TOKEN}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/hello-world:${_BUILD_TAG}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/hello-world:${_BUILD_NUM}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/hello-world:${_REVISION_TAG}'

--- a/src/greenpeace-testing/ubuntu/cloudbuild.yaml
+++ b/src/greenpeace-testing/ubuntu/cloudbuild.yaml
@@ -4,8 +4,6 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
-      - '--build-arg'
-      - 'MICROSCANNER_TOKEN=${_MICROSCANNER_TOKEN}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_TAG}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_NUM}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_REVISION_TAG}'

--- a/src/greenpeace-testing/ubuntu/templates/Dockerfile.in
+++ b/src/greenpeace-testing/ubuntu/templates/Dockerfile.in
@@ -2,14 +2,6 @@ FROM phusion/baseimage:${BASEIMAGE_VERSION} as base
 
 COPY . /app/
 
-ARG MICROSCANNER_TOKEN
-
-ENV MICROSCANNER_TOKEN="${MICROSCANNER_TOKEN}"
-
-ADD https://get.aquasec.com/microscanner .
-
-RUN chmod 755 microscanner
-
 RUN rm -fr /etc/apt/sources.list && \
     ln -s /app/sources.list /etc/apt/sources.list && \
     apt-get update && \
@@ -22,8 +14,6 @@ RUN rm -fr /etc/apt/sources.list && \
     tar -C /app/bin -xzvf dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz && \
     rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz && \
     rm -fr /usr/share/man/* /usr/share/doc/*
-
-RUN ./microscanner "${MICROSCANNER_TOKEN}"
 
 FROM scratch
 
@@ -42,7 +32,6 @@ ENV \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
     LC_ALL="en_US.UTF-8" \
-    MICROSCANNER_TOKEN="" \
     PATH="/app/bin:$PATH"
 
 WORKDIR /app

--- a/src/planet-4-151612/cloudbuild.yaml
+++ b/src/planet-4-151612/cloudbuild.yaml
@@ -15,8 +15,6 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
-      - '--build-arg'
-      - 'MICROSCANNER_TOKEN=${_MICROSCANNER_TOKEN}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_TAG}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_NUM}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_REVISION_TAG}'

--- a/src/planet-4-151612/ubuntu/cloudbuild.yaml
+++ b/src/planet-4-151612/ubuntu/cloudbuild.yaml
@@ -4,8 +4,6 @@ steps:
     name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
-      - '--build-arg'
-      - 'MICROSCANNER_TOKEN=${_MICROSCANNER_TOKEN}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_TAG}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_BUILD_NUM}'
       - '--tag=${_BUILD_NAMESPACE}/${_GOOGLE_PROJECT_ID}/ubuntu:${_REVISION_TAG}'

--- a/src/planet-4-151612/ubuntu/templates/Dockerfile.in
+++ b/src/planet-4-151612/ubuntu/templates/Dockerfile.in
@@ -1,11 +1,5 @@
 FROM phusion/baseimage:${BASEIMAGE_VERSION} as base
 
-ARG MICROSCANNER_TOKEN
-
-ENV MICROSCANNER_TOKEN="${MICROSCANNER_TOKEN}"
-
-RUN if [ -z "${MICROSCANNER_TOKEN}" ]; then { echo "ERROR: MICROSCANNER_TOKEN not set"; exit 1; }; fi
-
 COPY . /app/
 
 # hadolint ignore=DL3008
@@ -34,12 +28,6 @@ RUN wget -nv https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE
 
 RUN rm -fr /etc/service/sshd
 
-ADD https://get.aquasec.com/microscanner .
-
-RUN chmod 755 microscanner
-
-RUN ./microscanner ${MICROSCANNER_TOKEN}
-
 FROM scratch
 
 COPY --from=base / /
@@ -56,7 +44,6 @@ ENV \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
     LC_ALL="en_US.UTF-8" \
-    MICROSCANNER_TOKEN="" \
     PATH="/app/bin:$PATH"
 
 WORKDIR /app

--- a/tests/src/planet-4-151612/php-fpm/tests/00_microscanner.bats
+++ b/tests/src/planet-4-151612/php-fpm/tests/00_microscanner.bats
@@ -1,8 +1,0 @@
-#!/usr/bin/env bats
-set -e
-
-load env
-
-@test "microscanner" {
-  docker run --rm "$image" /microscanner ${MICROSCANNER_TOKEN}
-}


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6051

---

Microscanner is deprecated. Instead we can use Trivy for scanning for vulnerabilities.

We already had Trivy on the CI image. And we also just [updated it](https://github.com/greenpeace/planet4-circleci/commit/70f3b606eeec56c67943d9fc94fc18ea5400a280) to the latest version.

**Testing**

The `scan-wordpress` and all `scan` jobs in [the CI](https://app.circleci.com/pipelines/github/greenpeace/planet4-docker/284/workflows/4068946c-e5c0-4513-b16d-bc97f68a9b5a/jobs/10156/artifacts) should have a vulnerability report, similar to what Microscanner was doing. Added one more step to store it as an artifact.