### PR TITLE
PLANET-5963 Install APM agent and set configuration

### DIFF
--- a/config.default
+++ b/config.default
@@ -47,6 +47,8 @@ NGX_PAGESPEED_VERSION=latest
 # https://openresty.org/en/download.html
 OPENRESTY_VERSION=1.15.8.2
 OPENRESTY_SOURCE=source
+# https://github.com/elastic/apm-agent-php/releases
+APM_AGENT_PHP_VERSION=1.0.1
 
 PHP_MAJOR_VERSION=7.3
 

--- a/src/planet-4-151612/php-fpm/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl
+++ b/src/planet-4-151612/php-fpm/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl
@@ -1,0 +1,18 @@
+; This file contains the various settings for the Elastic APM PHP agent. For
+; further details refers to the following URL:
+; https://www.elastic.co/guide/en/apm/agent/php/current/configuration-reference.html
+;
+
+[elastic]
+elastic_apm.enabled = {{ .Env.ELASTIC_APM_ENABLED }}
+elastic_apm.environment = "{{ .Env.APP_ENV }}"
+elastic_apm.log_level = "INFO"
+elastic_apm.log_level_stderr = "INFO"
+elastic_apm.secret_token = "{{ .Env.ELASTIC_APM_SECRET_TOKEN }}"
+elastic_apm.server_timeout = "30s"
+elastic_apm.server_url = "http://apm-apm-server.elastic.svc.cluster.local:8200"
+elastic_apm.service_name = "{{ .Env.MYSQL_USER }}-{{ .Env.APP_ENV }}"
+;elastic_apm.service_version = "REPLACE_WITH_OUTPUT_FROM_git rev-parse HEAD"
+elastic_apm.transaction_max_spans = 500
+elastic_apm.transaction_sample_rate = 1.0
+elastic_apm.verify_server_cert = true

--- a/src/planet-4-151612/wordpress/etc/my_init.d/30_install_elastic_apm.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/30_install_elastic_apm.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+wget --retry-connrefused --waitretry=1 -t 5 "https://github.com/elastic/apm-agent-php/releases/download/v1.0.1/apm-agent-php_${APM_AGENT_PHP_VERSION}_all.deb.sha512"
+wget --retry-connrefused --waitretry=1 -t 5 "https://github.com/elastic/apm-agent-php/releases/download/v1.0.1/apm-agent-php_${APM_AGENT_PHP_VERSION}_all.deb"
+
+sha512sum -c "apm-agent-php_${APM_AGENT_PHP_VERSION}_all.deb.sha512"
+
+dpkg -i "apm-agent-php_${APM_AGENT_PHP_VERSION}_all.deb"

--- a/src/planet-4-151612/wordpress/etc/my_init.d/95_elastic_apm.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/95_elastic_apm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+dockerize -template /app/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl:/opt/elastic/apm-agent-php/etc/elastic-apm-custom.ini

--- a/src/planet-4-151612/wordpress/etc/rc.docker.d/20_elastic_apm.sh
+++ b/src/planet-4-151612/wordpress/etc/rc.docker.d/20_elastic_apm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+dockerize -template /app/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl:/opt/elastic/apm-agent-php/etc/elastic-apm-custom.ini

--- a/src/planet-4-151612/wordpress/templates/Dockerfile.in
+++ b/src/planet-4-151612/wordpress/templates/Dockerfile.in
@@ -30,8 +30,8 @@ ENV \
     OVERWRITE_EXISTING_FILES="false" \
     PHP_CLEAR_ENV="yes" \
     SMARTSHEET_API_KEY="" \
-    ELASTIC_APM_SERVICE_NAME="${APPLICATION_NAME}" \
-    ELASTIC_APM_SERVER_URL="http://apm-apm-server.elastic.svc.cluster.local:8200/" \
+    ELASTIC_APM_ENABLED="true" \
+    APM_AGENT_PHP_VERSION="${APM_AGENT_PHP_VERSION}" \
     WP_ADMIN_EMAIL="${MAINTAINER_EMAIL}" \
     WP_ADMIN_NAME="" \
     WP_ADMIN_PASS="" \

--- a/src/planet-4-151612/wordpress/templates/README.md.in
+++ b/src/planet-4-151612/wordpress/templates/README.md.in
@@ -32,8 +32,6 @@ OVERWRITE_FILES | false | Set true to force install Wordpress and overwrite the 
 CLOUDFLARE_API_KEY | | The key used to send edge cache purges when content changes
 SMARTSHEET_API_KEY | | API key for the Smartsheet integration, associated with a functional account
 ELASTIC_APM_SECRET_TOKEN | | API token for the Elastic APM service
-ELASTIC_APM_SERVICE_NAME | | App name to set in the Elastic APM service
-ELASTIC_APM_SERVER_URL | | API url for the Elastic APM service
 WP_TITLE | greenpeace/wordpress | The title of the Wordpress install
 WP_HOSTNAME |  | Wordpress URL. Tries to fallback to `$APP_HOSTNAME` if blank
 WP_DB_HOST | db | Database hostname

--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -106,7 +106,7 @@ define('CLOUDFLARE_API_KEY', '{{ .Env.CLOUDFLARE_API_KEY }}');
 /**
  * Elastic APM settings
  */
-define( 'ELASTIC_APM_SECRET_TOKEN', '{{ .Env.ELASTIC_APM_SECRET_TOKEN }}' );
+define('ELASTIC_APM_SECRET_TOKEN', '{{ .Env.ELASTIC_APM_SECRET_TOKEN }}');
 
 /**
  * WordPress Database Table prefix.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5963

---

Install APM php agent using their .deb package and doing some basic hash validation. Then use environment variables to populate its custom configuration file.

For used `MYSQL_USER` for setting service name per app. It doesn't seem right, but it's the only variable I tested to give a meaningful value. Not sure why we duplicate config scripts on `my_init.d` and `rc.docker.d`, but I followed existing structure.