### PR TITLE
PLANET-6023: Keep wp configuration file between runs

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -245,7 +245,10 @@ wp --root core download --version="${WP_VERSION}" --force "${WP_DOWNLOAD_FLAGS}"
 $composer_exec copy:themes
 $composer_exec copy:plugins
 
-setuser "${APP_USER}" dockerize -template "/app/wp-config.php.tmpl:${PUBLIC_PATH}/wp-config.php"
+# Generate wp config file
+chown -f "${APP_USER}" /app/bin/generate_wp*
+setuser "${APP_USER}" /app/bin/generate_wp_keys.sh
+setuser "${APP_USER}" /app/bin/generate_wp_config.sh
 
 # Wait up to two minutes for the database to become ready
 timeout=2

--- a/src/planet-4-151612/wordpress/etc/my_init.d/90_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/90_wordpress.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 # Executed after my_init.d and environment is established
 
-# Generates keys and salts for wp-config.php
-/app/bin/generate_wp_keys.sh
+# Create wp-config.php file, overwrite if not in development environment
+if [[ ! -f "${PUBLIC_PATH}/wp-config.php" ]] || [[ "${APP_ENV}" != "develop"* ]]; then
+  # Generates keys and salts for wp-config.php
+  /app/bin/generate_wp_keys.sh
 
-# Write the wp-config.php file from template
-/app/bin/generate_wp_config.sh
+  # Write the wp-config.php file from template
+  /app/bin/generate_wp_config.sh
+fi
 
 # Wait up to two minutes for the database to become ready
 timeout=2


### PR DESCRIPTION
Current code overwrites `wp-config.php` file every time the php container starts (start/up/build).  
It stops developers from experimenting on configuration during long developments.  
For [PLANET-6023](https://github.com/greenpeace/planet4-docker-compose/pull/79), it prevents switching between databases and reliably getting the same instance back when you restart docker.

## Fix

This modification writes a config file in development environment only if it doesn't exist.  
It is limited to development only so that arbitrary configuration cannot be set by accident in production, it will still be overwritten by the container generated one.

## Test

- While your containers are running, add a change to your `persistence/app/public/wp-config.php` file.
- Run `make stop && make start`
  - your change should have disappeared
- Reintroduce your change, and run `make stop && APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-6023 make start`
  - your change should still be there
- On a clean install, `APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-6023 make dev` should still create a `wp-config.php` file 