### PR TITLE
Make `make init` work on initial checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ ignore:
 
 .git/hooks/%:
 	@chmod 755 .githooks/*
-	@find .git/hooks -type l -exec rm {} \;
-	@find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
+	@find .git/hooks -type l -exec rm {} \; 2> /dev/null || echo ""
+	@mkdir -p .git/hooks && find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
 
 ################################################################################
 


### PR DESCRIPTION
This fixes two things:

1. `find .git/hooks -type l` will fail on clean repo checkout (b/c .git/hooks doesn't exist). Hence we send "find: .git/hooks: No such file or directory" to dev/null and use `|| echo ""` in keeping with the goal of the `@` syntax (keeping silent about what command is run; otherwise we'd use `-` at start of recipe to have Make ignore the failure).  ... we could also use `true` instead of `echo ""` but that might be splitting hairs.
2. ` -exec ln -sf ../../{} .git/hooks/` fails for same reason, and is fixed by making the directory (if it doesn't exist) first.