### PR TITLE
Revert "PLANET-6023: Keep wp configuration file between runs"

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -245,10 +245,7 @@ wp --root core download --version="${WP_VERSION}" --force "${WP_DOWNLOAD_FLAGS}"
 $composer_exec copy:themes
 $composer_exec copy:plugins
 
-# Generate wp config file
-chown -f "${APP_USER}" /app/bin/generate_wp*
-setuser "${APP_USER}" /app/bin/generate_wp_keys.sh
-setuser "${APP_USER}" /app/bin/generate_wp_config.sh
+setuser "${APP_USER}" dockerize -template "/app/wp-config.php.tmpl:${PUBLIC_PATH}/wp-config.php"
 
 # Wait up to two minutes for the database to become ready
 timeout=2

--- a/src/planet-4-151612/wordpress/etc/my_init.d/90_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/90_wordpress.sh
@@ -3,14 +3,11 @@ set -euo pipefail
 
 # Executed after my_init.d and environment is established
 
-# Create wp-config.php file, overwrite if not in development environment
-if [[ ! -f "${PUBLIC_PATH}/wp-config.php" ]] || [[ "${APP_ENV}" != "develop"* ]]; then
-  # Generates keys and salts for wp-config.php
-  /app/bin/generate_wp_keys.sh
+# Generates keys and salts for wp-config.php
+/app/bin/generate_wp_keys.sh
 
-  # Write the wp-config.php file from template
-  /app/bin/generate_wp_config.sh
-fi
+# Write the wp-config.php file from template
+/app/bin/generate_wp_config.sh
 
 # Wait up to two minutes for the database to become ready
 timeout=2


### PR DESCRIPTION
Reverts greenpeace/planet4-docker#70

This change breaks [Acceptance tests](https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/4263/workflows/0e8a7b47-955e-43e7-8473-1df3c1f8736f/jobs/15499) in other repos, with message
`php-fpm_1        | Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `db:3306`. This could mean your host’s database server is down.`

I'll check different solutions (implementing the `local` environment keyword looks like the more reliable one)