### PR TITLE
Declare local env and don't overwrite wp-config file

### DIFF
--- a/src/planet-4-151612/exim/etc/service/exim/run
+++ b/src/planet-4-151612/exim/etc/service/exim/run
@@ -22,7 +22,7 @@ fi
 #   EXIM email redirect
 # -----------------------------------------------------------------------------
 
-if [[ "${APP_ENV}" =~ develop ]]; then
+if [[ "${APP_ENV}" =~ develop ]] || [[ "${APP_ENV}" = "local" ]]; then
   _good "exim4:  re-routing all outgoing email to ${EXIM_ADMIN_EMAIL}"
 else
   rm -fr /etc/exim4/conf.d/router/190_exim4-config_intercept

--- a/src/planet-4-151612/php-fpm/templates/README.md.in
+++ b/src/planet-4-151612/php-fpm/templates/README.md.in
@@ -18,7 +18,7 @@ This container is configurable via a plethora of environment variables, some of 
 
 var | default | description
 --- | ------- | -----------
-APP_ENV | ${APP_ENV} | production, develop
+APP_ENV | ${APP_ENV} | production, develop, local
 APP_GID | 1000 | group_id
 APP_GROUP | app | nginx and php5-fpm group
 APP_HOSTNAME | `hostname -f` |  hostname of application

--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -210,7 +210,7 @@ composer_exec="time setuser ${APP_USER} composer -vv --no-ansi"
 #   $composer_exec update
 # fi
 
-if [[ $APP_ENV =~ develop ]]; then
+if [[ $APP_ENV =~ develop ]] || [[ "${APP_ENV}" = "local" ]]; then
   composer_install_flags=" --prefer-dist"
 else
   composer_install_flags=" --prefer-dist --no-dev"
@@ -245,7 +245,10 @@ wp --root core download --version="${WP_VERSION}" --force "${WP_DOWNLOAD_FLAGS}"
 $composer_exec copy:themes
 $composer_exec copy:plugins
 
-setuser "${APP_USER}" dockerize -template "/app/wp-config.php.tmpl:${PUBLIC_PATH}/wp-config.php"
+# Generate wp config file
+chown -f "${APP_USER}" /app/bin/generate_wp*
+setuser "${APP_USER}" /app/bin/generate_wp_keys.sh
+setuser "${APP_USER}" /app/bin/generate_wp_config.sh
 
 # Wait up to two minutes for the database to become ready
 timeout=2

--- a/src/planet-4-151612/wordpress/etc/my_init.d/90_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/90_wordpress.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 # Executed after my_init.d and environment is established
 
-# Generates keys and salts for wp-config.php
-/app/bin/generate_wp_keys.sh
+# Create wp-config.php file, overwrite if not in local environment
+if [[ ! -f "${PUBLIC_PATH}/wp-config.php" ]] || [[ "${APP_ENV}" != "local" ]]; then
+  # Generates keys and salts for wp-config.php
+  /app/bin/generate_wp_keys.sh
 
-# Write the wp-config.php file from template
-/app/bin/generate_wp_config.sh
+  # Write the wp-config.php file from template
+  /app/bin/generate_wp_config.sh
+fi
 
 # Wait up to two minutes for the database to become ready
 timeout=2

--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -57,7 +57,7 @@ define('SECURE_AUTH_SALT', '{{ .Env.WP_SECURE_AUTH_SALT }}');
 define('LOGGED_IN_SALT',   '{{ .Env.WP_LOGGED_IN_SALT }}');
 define('NONCE_SALT',       '{{ .Env.WP_NONCE_SALT }}');
 
-{{ if eq .Env.APP_ENV "develop" }}
+{{ if eq .Env.APP_ENV "local" "develop" }}
 define( 'WP_DEBUG', true );
 define( 'WP_DEBUG_LOG', true );
 define( 'SCRIPT_DEBUG', true );


### PR DESCRIPTION
Related to: https://github.com/greenpeace/planet4-docker-compose/pull/79

Following https://github.com/greenpeace/planet4-docker/pull/70 , this is a different approach implementing a `local` keyword for APP_ENV variable in the php-fpm container.

This time :grimacing:  I think I tested it til the end https://app.circleci.com/pipelines/github/greenpeace/planet4-plugin-gutenberg-blocks/4370/workflows/e7682422-28dc-4f48-a1d2-f2b58ecd8986/jobs/16162 with https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/commit/90ae797cc0ff5dbe01965b192ea47ef3da151958

In addition to this, I'll make a PR modifying the default configuration of APP_ENV in docker-compose.yml

## Test

On your local test instance:
- `make down`
- modify your wp-config,php file
- `APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-6023-bis APP_ENV=local make run`
- your config file should be the same