### PR TITLE
Fix composer install error on artifacts directory

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -8,6 +8,7 @@ install_lock="${SOURCE_PATH}/.install"
 _good "Setting permissions of composer to ${APP_USER}..."
 chown -f "${APP_USER}" /app/bin/composer
 chown -fR "${APP_USER}" /app/.composer
+mkdir -p "${SOURCE_PATH}/artifacts" && chown -fR "${APP_USER}" "${SOURCE_PATH}/artifacts"
 
 # ==============================================================================
 # UTILITY FUNCTIONS


### PR DESCRIPTION
Local installation with `make dev` generates an error during installation:
> [UnexpectedValueException]
> RecursiveDirectoryIterator::__construct(/app/source/artifacts/): failed to open dir: No such file or directory

Nightly pipeline failing:
https://app.circleci.com/pipelines/github/greenpeace/planet4-docker-compose/558/workflows/b9c819dd-48f6-44f2-934e-b39ffddec1ee/jobs/982

Code related to composer artifacts:
https://github.com/greenpeace/planet4-base/commit/620411d846de17b52aee8b1058e4ae158779e7b6#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34

## Fix 

Creating artifacts directory in advance with proper access rights to fix the error.

## Test

- `make dev` on a fresh `planet4-docker-compose` clone currently fails
- `APP_IMAGE=gcr.io/planet-4-151612/wordpress:fix-composer-artifacts make dev` passes