### PR TITLE
PLANET-5963: Add condition to APM agent installation

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/30_install_elastic_apm.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/30_install_elastic_apm.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+[[ "${INSTALL_APM_AGENT}" = "true" ]] || exit 0
+
 wget --retry-connrefused --waitretry=1 -t 5 "https://github.com/elastic/apm-agent-php/releases/download/v1.0.1/apm-agent-php_${APM_AGENT_PHP_VERSION}_all.deb.sha512"
 wget --retry-connrefused --waitretry=1 -t 5 "https://github.com/elastic/apm-agent-php/releases/download/v1.0.1/apm-agent-php_${APM_AGENT_PHP_VERSION}_all.deb"
 

--- a/src/planet-4-151612/wordpress/etc/my_init.d/95_elastic_apm.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/95_elastic_apm.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-dockerize -template /app/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl:/opt/elastic/apm-agent-php/etc/elastic-apm-custom.ini
+if [[ -d "/opt/elastic/apm-agent-php/etc/" ]]; then
+  dockerize -template /app/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl:/opt/elastic/apm-agent-php/etc/elastic-apm-custom.ini
+fi

--- a/src/planet-4-151612/wordpress/etc/rc.docker.d/20_elastic_apm.sh
+++ b/src/planet-4-151612/wordpress/etc/rc.docker.d/20_elastic_apm.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-dockerize -template /app/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl:/opt/elastic/apm-agent-php/etc/elastic-apm-custom.ini
+if [[ -d "/opt/elastic/apm-agent-php/etc/" ]]; then
+  dockerize -template /app/templates/etc/php/fpm/conf.d/30-elastic-apm-custom.ini.tmpl:/opt/elastic/apm-agent-php/etc/elastic-apm-custom.ini
+fi

--- a/src/planet-4-151612/wordpress/templates/Dockerfile.in
+++ b/src/planet-4-151612/wordpress/templates/Dockerfile.in
@@ -23,6 +23,7 @@ ENV \
     DELETE_EXISTING_FILES="false" \
     GIT_REF="main" \
     GIT_SOURCE="${GIT_SOURCE}" \
+    INSTALL_APM_AGENT="true" \
     INSTALL_WORDPRESS="true" \
     MERGE_REF="" \
     MERGE_SOURCE="" \


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5963

APM is not usually used on local environment, adding a variable to its installation process will allow to trigger or skip it, depending on the context.

## Test

Test with https://github.com/greenpeace/planet4-docker-compose/compare/planet-5963-cond or configure `INSTALL_APM_AGENT` in your docker-compose.yml file.
- Default `APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-5963-cond make dev-from-release` won't install APM agent
- `APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-5963-cond INSTALL_APM_AGENT=true make dev-from-release` installs apm agent, you get logs displaying during install and can check apm files exist in `make php-shell`: `/opt/elastic/apm-agent-php/`