### PR TITLE
PLANET-6018: Skip install lock on local environment

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -51,10 +51,16 @@ function delete_source_directories() {
   rm -fr "${PUBLIC_PATH}:?}/*" "${PUBLIC_PATH}/.*" >/dev/null 2>&1 || true
 }
 # ==============================================================================
+# create_source_path()
+#
+function create_source_path() {
+  [[ ! -e "${SOURCE_PATH}" ]] && _good "Creating ${SOURCE_PATH} ..." && mkdir -p "${SOURCE_PATH}"
+  return 0
+}
+# ==============================================================================
 # touch_install_lock()
 #
 function touch_install_lock() {
-  [[ ! -e "${SOURCE_PATH}" ]] && _good "Creating ${SOURCE_PATH} ..." && mkdir -p "${SOURCE_PATH}"
   _good "Creating install lock file: ${install_lock}"
   true >"${install_lock}"
 }
@@ -79,6 +85,7 @@ sleep ".${milliseconds}"
 
 num_files="$(get_num_files_exist)"
 
+# Install-lock system resolution
 sync
 if [[ -f "${install_lock}" ]]; then
   _good "Installation already underway, ${install_lock} exists. Sleeping..."
@@ -90,7 +97,11 @@ if [[ -f "${install_lock}" ]]; then
   exit 0
 fi
 
-touch_install_lock
+# Create install lock in potential concurrent install environments only
+create_source_path
+if [[ "${APP_ENV}" != "local" ]]; then
+  touch_install_lock
+fi
 
 _good "Number of files in source folder: ${num_files}"
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6018

Skip lock creation on installation on local environment, so that infinite loop doesn't happen during development

## Test

- Run a new install with `APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-6018 make dev` 
- During installation, check logs with `docker-compose logs -f php-fpm`
  - On a usual `make dev`, the php-fpm logs will indicate `php-fpm_1    |   * Creating install lock file: /app/source/.install` (just after `Sleeping x ms ...` and before `Number of files in source folder: 2`
  - On this branch, this step never happens
  - Running this branch with a different environment will still install the lock, eg `APP_IMAGE=gcr.io/planet-4-151612/wordpress:planet-6018 APP_ENV=develop make dev`

~Note that this step already never happens for `make dev-from-release`, because installation files are already there, so this script is mostly skipped.~