### PR TITLE
PLANET-5948 Add Referrer-Policy header

### DIFF
--- a/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
+++ b/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
@@ -1,6 +1,13 @@
 # don't send the nginx version number in error pages and Server header
 server_tokens off;
 
+# This header determines what origin information an external site
+# gets when a user is linked there from our websites.
+# https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+# We defaulting to 'origin-strict' which will only sent the origin domain
+# (not the path) only on https destinations.
+add_header Referrer-Policy "strict-origin";
+
 # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
 # to disable content-type sniffing on some browsers.
 # https://www.owasp.org/index.php/List_of_useful_HTTP_headers


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5948

---

This header determines what origin information an external site gets when a user is linked there from our websites [Documentation](https://scotthelme.co.uk/a-new-security-header-referrer-policy/). We are defaulting to 'origin-strict' which will only sent the origin domain (not the path) only on https destinations.

### Testing
- This is [a report](https://securityheaders.com/?q=https%3A%2F%2Fwww.greenpeace.org%2Finternational%2F%2F&hide=on&followRedirects=on) from `international` without the header.
- This is [a report](https://securityheaders.com/?q=https%3A%2F%2Fwww-dev.greenpeace.org%2Fcidev%2F&hide=on&followRedirects=on) from `cidev` with the header.

```
curl -I https://www-dev.greenpeace.org/cidev/
...
referrer-policy: strict-origin
```