### PR TITLE
PLANET-5948 Add Permission-Policy header

### DIFF
--- a/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
+++ b/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
@@ -3,10 +3,14 @@ server_tokens off;
 
 # This header determines what origin information an external site
 # gets when a user is linked there from our websites.
-# https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
 # We defaulting to 'origin-strict' which will only sent the origin domain
 # (not the path) only on https destinations.
 add_header Referrer-Policy "strict-origin";
+
+# This header determines which browser features are allowed.
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+add_header Permissions-Policy "geolocation=(),sync-xhr=(),microphone=(),camera=(),fullscreen=(),payment=()";
 
 # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
 # to disable content-type sniffing on some browsers.


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5948

---

As a first iteration, this includes a few permissions that can allow
certain browser features that NROs can potentially use when they build
custom blocks and plugins.

### Testing

This currently runs on `cidev` giving us an "A" rate on the [scan report](https://securityheaders.com/?q=https%3A%2F%2Fwww-dev.greenpeace.org%2Fcidev%2F&hide=on&followRedirects=on).

```
curl -I https://www-dev.greenpeace.org/cidev/
permissions-policy: geolocation=(),sync-xhr=(),microphone=(),camera=(),fullscreen=(),payment=()
```