### PR TITLE
Allow WP_VERSION override from CI env variable

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -242,10 +242,11 @@ fi
 
 chown -R "${APP_USER}:${APP_USER}" "$PUBLIC_PATH"
 
-WP_VERSION=$(jq -r '.extra["wp-version"] // empty' <"${SOURCE_PATH}"/composer.json)
+if [[ -z "${WP_VERSION}" ]]; then
+  WP_VERSION=$(jq -r '.extra["wp-version"] // empty' <"${SOURCE_PATH}"/composer.json)
+fi
 export WP_VERSION
 echo "Using WP_VERSION: ${WP_VERSION}"
-echo
 
 if [ -z "$WP_VERSION" ]; then
   echo "WP_VERSION not set"


### PR DESCRIPTION
Get `WP_VERSION` from base composer only when it's not set already. That allows us to override on an NRO or environment level by adding a `WP_VERSION` variable.

In order for this to work we need to remove the fallback value from builder in https://github.com/greenpeace/planet4-builder/pull/87

### Testing

Not easy to test locally, so I used `cidev` to test it. 

1. First I [added the env varialbe](https://github.com/greenpeace/planet4-cidev/commit/fb7df5c75f2d27bbb82bcaa39a6e746e04988e53) and indeed looking into `make bake` in [CI output](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/1295/workflows/0f91a64b-e2eb-4203-9f04-71816d4d7fcb/jobs/3600) you can see: `Using WP_VERSION: 5.8.1`
2. Removed that line and it used the fallback from base repo. Looking into the [CI output](https://app.circleci.com/pipelines/github/greenpeace/planet4-cidev/1299/workflows/543a20c0-f8ab-4c85-8155-4456396154c1/jobs/3608) you can see: `Using WP_VERSION: 5.6.4`.