### PR TITLE
PLANET-6306: Switch to PHP 7.4

### DIFF
--- a/config.default
+++ b/config.default
@@ -50,7 +50,7 @@ OPENRESTY_SOURCE=source
 # https://github.com/elastic/apm-agent-php/releases
 APM_AGENT_PHP_VERSION=1.0.1
 
-PHP_MAJOR_VERSION=7.3
+PHP_MAJOR_VERSION=7.4
 
 SOURCE_PATH=/app/source
 PUBLIC_PATH=/app/source/public

--- a/src/planet-4-151612/php-fpm/templates/Dockerfile.in
+++ b/src/planet-4-151612/php-fpm/templates/Dockerfile.in
@@ -16,7 +16,6 @@ RUN wget --retry-connrefused --waitretry=1 -t 5 -O - https://download.newrelic.c
       php${PHP_MAJOR_VERSION}-imagick \
       php${PHP_MAJOR_VERSION}-mbstring \
       php${PHP_MAJOR_VERSION}-mysql \
-      php${PHP_MAJOR_VERSION}-recode \
       php${PHP_MAJOR_VERSION}-redis \
       php${PHP_MAJOR_VERSION}-xml \
       php${PHP_MAJOR_VERSION}-zip \


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6306

- Update PHP version
- Remove php-recode extension, not available on PHP >= 7.4
Function recode is apparently not needed anymore (it was used in the archived project https://github.com/greenpeace/planet4-appengine-phpmyadmin), if it is needed see https://www.php.net/manual/en/recode.installation.php