### PR TITLE
PLANET-6307 Get WP_VERSION from NRO composer or fallback to base

### DIFF
--- a/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
+++ b/src/planet-4-151612/wordpress/etc/my_init.d/20_install_wordpress.sh
@@ -242,16 +242,17 @@ fi
 
 chown -R "${APP_USER}:${APP_USER}" "$PUBLIC_PATH"
 
-if [[ -z "${WP_VERSION}" ]]; then
+# Get WP_VERSION from NRO. If it's empty fallback to base.
+WP_VERSION=$(jq -r '.extra["wp-version"] // empty' <"${SOURCE_PATH}"/composer-local.json)
+if [ -z "$WP_VERSION" ]; then
   WP_VERSION=$(jq -r '.extra["wp-version"] // empty' <"${SOURCE_PATH}"/composer.json)
 fi
-export WP_VERSION
-echo "Using WP_VERSION: ${WP_VERSION}"
-
 if [ -z "$WP_VERSION" ]; then
   echo "WP_VERSION not set"
   exit 1
 fi
+export WP_VERSION
+echo "Using WP_VERSION: ${WP_VERSION}"
 
 wp --root core download --version="${WP_VERSION}" --force "${WP_DOWNLOAD_FLAGS}"
 


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6307

---

Since `make bake` writes after we have merged and rewritten composer files, we can use them to get `wp-version`. This allows to override default base value from an nro repo.

Since we will have https://github.com/greenpeace/planet4-builder/pull/88 in place and environment files will already be merged to composer, we can even override per environment.