### PR TITLE
Swich Referrer-Policy to strict-origin-when-cross-origin

### DIFF
--- a/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
+++ b/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
@@ -4,9 +4,10 @@ server_tokens off;
 # This header determines what origin information an external site
 # gets when a user is linked there from our websites.
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
-# We defaulting to 'origin-strict' which will only sent the origin domain
-# (not the path) only on https destinations.
-add_header Referrer-Policy "strict-origin";
+# We defaulting to 'strict-origin-when-cross-origin' which will only send
+# the full url on same-origin requrests and only origin domain
+# (not the path) on cross-origin destinations. Both only on https.
+add_header Referrer-Policy "strict-origin-when-cross-origin";
 
 # This header determines which browser features are allowed.
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6445

---

The initial value resulted in some WP actions not be redirect properly. 
`strict-origin-when-cross-origin` actually makes more sense.

According to the [standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy):
```
Send the origin, path, and querystring when performing a same-origin
request. For cross-origin requests send the origin (only) when the
protocol security level stays same (HTTPS→HTTPS). Don't send the Referer
header to less secure destinations (HTTPS→HTTP).
```