### PR TITLE
Add php-intl extension to handle languages breaks/boundaries

### DIFF
--- a/src/planet-4-151612/php-fpm/templates/Dockerfile.in
+++ b/src/planet-4-151612/php-fpm/templates/Dockerfile.in
@@ -11,6 +11,7 @@ RUN add-apt-repository ppa:ondrej/php && \
       php${PHP_MAJOR_VERSION}-fpm \
       php${PHP_MAJOR_VERSION}-gd \
       php${PHP_MAJOR_VERSION}-imagick \
+      php${PHP_MAJOR_VERSION}-intl \
       php${PHP_MAJOR_VERSION}-mbstring \
       php${PHP_MAJOR_VERSION}-mysql \
       php${PHP_MAJOR_VERSION}-redis \


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6432
Doc: https://www.php.net/manual/en/intro.intl.php

Also relevant: https://make.wordpress.org/hosting/2021/05/20/why-hosters-should-install-the-php-intl-extension/