### PR TITLE
Allow configuring a custom 404 page

### DIFF
--- a/src/planet-4-151612/openresty/templates/etc/nginx/sites-enabled/default-ssl.conf.tmpl
+++ b/src/planet-4-151612/openresty/templates/etc/nginx/sites-enabled/default-ssl.conf.tmpl
@@ -13,6 +13,10 @@ server {
     {{ else }}
     index index.html;
     {{ end }}
+    
+    {{ if .Env.CUSTOM_404 }}
+    error_page 404 {{ .Env.CUSTOM_404 }};
+    {{ end }}
 
     ssl on;
 

--- a/src/planet-4-151612/openresty/templates/etc/nginx/sites-enabled/default.conf.tmpl
+++ b/src/planet-4-151612/openresty/templates/etc/nginx/sites-enabled/default.conf.tmpl
@@ -11,6 +11,10 @@ server {
     {{ else }}
     index index.html;
     {{ end }}
+    
+    {{ if .Env.CUSTOM_404 }}
+    error_page 404 {{ .Env.CUSTOM_404 }};
+    {{ end }}
 
     include server.d/*.conf;
 


### PR DESCRIPTION
Due to the current issue with the site not showing 404 pages properly. We need to configure a custom 404 page in the landing site. The landing site uses the openresty image from P4 and requires configuration through environment variables. We have to add the environment variable here to configure the 404 page then we can direct the landing page to use the 404.html page included in the repo as the error page. Finally we can configure the landing page as the default backend for nginx so that any requests are routed there and therefore to the custom 404 page.