### PR TITLE
Skip cache for /wp-json/

### DIFF
--- a/src/planet-4-151612/openresty/templates/etc/nginx/server.d/10_php.conf.tmpl
+++ b/src/planet-4-151612/openresty/templates/etc/nginx/server.d/10_php.conf.tmpl
@@ -36,7 +36,7 @@ if ($query_string != "") {
 }
 
 # Don't cache uris containing the following segments
-if ($request_uri ~* "/wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml|health_*.php") {
+if ($request_uri ~* "/wp-admin/|/wp-json/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml|health_*.php") {
   set $skip_cache 1;
 }
 

--- a/src/planet-4-151612/openresty/templates/etc/nginx/server.d/10_php.conf.tmpl
+++ b/src/planet-4-151612/openresty/templates/etc/nginx/server.d/10_php.conf.tmpl
@@ -36,7 +36,7 @@ if ($query_string != "") {
 }
 
 # Don't cache uris containing the following segments
-if ($request_uri ~* "/wp-admin/|/wp-json/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml|health_*.php") {
+if ($request_uri ~* "/wp-admin/|/get-en-session-token|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml|health_*.php") {
   set $skip_cache 1;
 }
 


### PR DESCRIPTION
Nginx was caching the EN session token for too long, causing forms to use an expired key and fail.

I'll squash on merge.