### PR TITLE
Add WPML_ST_SYNC_TRANSLATION_FILES flag

### DIFF
--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -84,6 +84,10 @@ define( 'WP_STATELESS_MEDIA_JSON_KEY',          '{{ .Env.WP_STATELESS_MEDIA_JSON
 define( 'WP_STATELESS_MEDIA_SERVICE_ACCOUNT',   '{{ .Env.WP_STATELESS_MEDIA_SERVICE_ACCOUNT }}' );
 {{ end }}
 
+{{ if eq .Env.WPML_ST_SYNC_TRANSLATION_FILES "true" }}
+define( 'WPML_ST_SYNC_TRANSLATION_FILES', true );
+{{ end }}
+
 {{ end }}
 
 {{ if eq .Env.WP_REDIS_ENABLED "true" }}


### PR DESCRIPTION
Ref: https://wpml.org/documentation/getting-started-guide/string-translation/finding-strings-that-dont-appear-on-the-string-translation-page/#synchronizing-translation-files-for-sites-running-on-multiple-servers

---

This enables WPML String Translation to work with multiple pods.