### PR TITLE
compile openresty with debug

### DIFF
--- a/src/planet-4-151612/openresty/bin/install_openresty.sh
+++ b/src/planet-4-151612/openresty/bin/install_openresty.sh
@@ -101,7 +101,8 @@ else
     --with-ipv6 \
     --with-pcre-jit \
     --add-dynamic-module=/tmp/ngx_http_geoip2_module-${GEOIP2_VERSION} \
-    --add-module=/tmp/incubator-pagespeed-ngx-${NGX_PAGESPEED_VERSION}-${NGX_PAGESPEED_RELEASE}
+    --add-module=/tmp/incubator-pagespeed-ngx-${NGX_PAGESPEED_VERSION}-${NGX_PAGESPEED_RELEASE} \
+    --with-debug
   make -j${procs} install
   apt-get purge -yqq \
     autoconf \


### PR DESCRIPTION
@comzeradd Thoughts on compiling NGINX with the `--with-debug` flag. Should have negligible performance impact when not in debug mode and means it easier to switch openresty into debugging mode when required (don't have to do a special build and redeploy a site)

More info here: https://docs.nginx.com/nginx/admin-guide/monitoring/debugging/#compiling-nginx-opensource-binary