### PR TITLE
add workaround for wp-admin redirect

### DIFF
--- a/src/planet-4-151612/openresty/templates/etc/nginx/server.d/00_rewrite_path.conf.tmpl
+++ b/src/planet-4-151612/openresty/templates/etc/nginx/server.d/00_rewrite_path.conf.tmpl
@@ -4,3 +4,8 @@ location ~ ^/{{ .Env.APP_HOSTPATH }}/? {
     ngx.req.set_uri(uri, true)
   }
 }
+
+# workaround because I can't figure out how to get the redirects to work properly
+location ~ ^/wp-admin$ {
+  return 301 /{{ .Env.APP_HOSTPATH }}/wp-admin/;
+}


### PR DESCRIPTION
This PR adds a new location block into openresty that redirects the users explicitly to app_hostpath/wp-admin/ when they hit app_hostpath/wp-admin. I could not identify a more generic way to implement this that easily fits within our current architecture.

Still need to test what happens on sites which do not have an APP_HOSTPATH @comzeradd  do you have any examples ?

Jira https://jira.greenpeace.org/browse/PLANET-6279