### PR TITLE
Remove php8.1 packages

### DIFF
--- a/src/planet-4-151612/php-fpm/templates/Dockerfile.in
+++ b/src/planet-4-151612/php-fpm/templates/Dockerfile.in
@@ -19,6 +19,7 @@ RUN add-apt-repository ppa:ondrej/php && \
       php${PHP_MAJOR_VERSION}-zip \
       ssmtp \
       && \
+    apt-get purge -y php8.1-cli php8.1-common php8.1-opcache php8.1-phpdbg php8.1-readline && \
     apt-fast clean && \
     rm -fr /tmp/* /var/tmp/* /var/lib/apt/lists/* /var/cache/apt/apt-fast/*&& \
     rm -fr /usr/share/man/* /usr/share/doc/* /usr/share/locale/*


### PR DESCRIPTION
Something changed in Ubuntu php packages and 8.1 is pulled in and being used as the default version. Purging makes 7.4 work again.