### PR TITLE
PLANET-6867 Enable support for GF file upload with stateless

### DIFF
--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -72,6 +72,7 @@ define( 'WP_SENTRY_ENV', '{{ .Env.APP_ENV }}' );
 define( 'WP_STATELESS_MEDIA_BUCKET',            '{{ .Env.WP_STATELESS_MEDIA_BUCKET }}' );
 define( 'WP_STATELESS_MEDIA_MODE',              '{{ .Env.WP_STATELESS_MEDIA_MODE }}' );
 define( 'WP_STATELESS_MEDIA_ROOT_DIR',          '{{ .Env.WP_STATELESS_MEDIA_ROOT_DIR }}' );
+define( 'WP_STATELESS_COMPATIBILITY_GF',        true );
 
 {{ if .Env.WP_STATELESS_MEDIA_KEY_FILE_PATH }}
 define( 'WP_STATELESS_MEDIA_KEY_FILE_PATH',     '{{ .Env.WP_STATELESS_MEDIA_KEY_FILE_PATH }}' );


### PR DESCRIPTION
Enables support for Gravity Forms features: file upload field, post image field, custom file upload field type with WP-Stateless plugin

[JIRA 6867](https://jira.greenpeace.org/browse/PLANET-6867)

Ref: https://wp-stateless.github.io/docs/constants/