### PR TITLE
PLANET-6978 Allow browsers fullscreen feature

### DIFF
--- a/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
+++ b/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
@@ -11,7 +11,7 @@ add_header Referrer-Policy "strict-origin-when-cross-origin";
 
 # This header determines which browser features are allowed.
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
-add_header Permissions-Policy "geolocation=(),sync-xhr=(),microphone=(),camera=(),fullscreen=(),payment=()";
+add_header Permissions-Policy "geolocation=(),sync-xhr=(),microphone=(),camera=(),payment=()";
 
 # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
 # to disable content-type sniffing on some browsers.


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-6978

The issue is only reproduce on Google Chrome browser, the youtube embed video fullscreen not working.
By changing the `Permissions-Policy: fullscreen` the fullscreen functionality works for chrome browser.

I don't see any harm removing(not restricting the fullscreen) the fullscreen from Permissions-Policy, but if I am missing something please confirm.

Referance: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/fullscreen