### PR TITLE
PLANET-7793 Fix media library missing images issue

### DIFF
--- a/src/planet-4-151612/wordpress/wp-config.php.tmpl
+++ b/src/planet-4-151612/wordpress/wp-config.php.tmpl
@@ -73,6 +73,7 @@ define( 'WP_STATELESS_MEDIA_BUCKET',            '{{ .Env.WP_STATELESS_MEDIA_BUCK
 define( 'WP_STATELESS_MEDIA_MODE',              '{{ .Env.WP_STATELESS_MEDIA_MODE }}' );
 define( 'WP_STATELESS_MEDIA_ROOT_DIR',          '{{ .Env.WP_STATELESS_MEDIA_ROOT_DIR }}' );
 define( 'WP_STATELESS_COMPATIBILITY_GF',        true );
+define( 'WP_STATELESS_SKIP_ACL_SET',            true );
 
 {{ if .Env.WP_STATELESS_MEDIA_KEY_FILE_PATH }}
 define( 'WP_STATELESS_MEDIA_KEY_FILE_PATH',     '{{ .Env.WP_STATELESS_MEDIA_KEY_FILE_PATH }}' );


### PR DESCRIPTION
[PLANET-7793](https://jira.greenpeace.org/browse/PLANET-7793)

- Fix missing media library images on the first day of each month
- Add WP_STATELESS_SKIP_ACL_SET constant to support Google Storage buckets with uniform bucket-level access (no ACL support)