### PR TITLE
PLANET-7905 Remove deprecated header X-XSS-Protection

### DIFF
--- a/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
+++ b/src/planet-4-151612/openresty/etc/nginx/conf.d/security.conf
@@ -20,20 +20,3 @@ add_header Permissions-Policy "geolocation=(),sync-xhr=(self),microphone=(self),
 # http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx
 # 'soon' on Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=471020
 add_header X-Content-Type-Options nosniff;
-
-# This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
-# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
-# this particular website if it was disabled by the user.
-# https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-add_header X-XSS-Protection "1; mode=block";
-
-# with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
-# you can tell the browser that it can only download content from the domains you explicitly allow
-# http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-# https://www.owasp.org/index.php/Content_Security_Policy
-#
-# Change your application code to increase security by disabling 'unsafe-inline' 'unsafe-eval'
-# directives for css and js.
-# see: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-#
-# add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://ssl.google-analytics.com https://assets.zendesk.com https://connect.facebook.net; img-src 'self' https://ssl.google-analytics.com https://s-static.ak.facebook.com https://assets.zendesk.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://themes.googleusercontent.com; frame-src https://www.facebook.com https://s-static.ak.facebook.com; object-src 'none'";


### PR DESCRIPTION
The header has been deprecated for most browsers and its existence can potentially render the application susceptible to exploitation via Reflected XSS.

---

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7905

---

- This is practically removing one line of code.
- Also removed some unused commented CSP code, since we've moved that in the application level.
- No need to add `X-FRAME-OPTIONS` here, as we already do that in the [application level](https://github.com/greenpeace/planet4-master-theme/blob/v1.342.0/src/HttpHeaders.php#L58).

### Testing

Hard to test it locally but I deployed the change to the `cidev` instance.

Either on the Network tab of the browser development tools, or locally with `curl` you should be able to see the header missing.

```
curl -I "https://www-dev.greenpeace.org/cidev/?nocache"
```

There should be no `x-xss-protection: 1; mode=block` header, which should be there if you try any other site.